### PR TITLE
Adding analyzer for MarkupLine to warn when using string interpolation

### DIFF
--- a/src/Spectre.Console.Analyzer.Tests/Unit/Analyzers/UseMarkupLineInterpolatedAnalyzerTests.cs
+++ b/src/Spectre.Console.Analyzer.Tests/Unit/Analyzers/UseMarkupLineInterpolatedAnalyzerTests.cs
@@ -1,0 +1,89 @@
+namespace Spectre.Console.Analyzer.Tests.Unit.Analyzers;
+
+public class UseMarkupLineInterpolatedAnalyzerTests
+{
+    private static readonly DiagnosticResult _expectedDiagnostics = new(
+        Descriptors.S1030_AvoidInterpolationInMarkupLine.Id,
+        DiagnosticSeverity.Warning);
+
+    [Fact]
+    public async Task AnsiConsole_MarkupLine_With_Interpolation_Has_Warning()
+    {
+        const string Source = @"
+using Spectre.Console;
+
+class TestClass
+{
+    void TestMethod()
+    {
+        string world = ""World"";
+        AnsiConsole.MarkupLine($""[bold]Hello, {world}[/]"");
+    }
+}";
+
+        await SpectreAnalyzerVerifier<UseMarkupLineInterpolatedAnalyzer>
+            .VerifyAnalyzerAsync(Source, _expectedDiagnostics.WithLocation(9, 9));
+    }
+
+    [Fact]
+    public async Task AnsiConsoleExtension_MarkupLine_With_Interpolation_Has_Warning()
+    {
+        const string Source = @"
+using Spectre.Console;
+
+class TestClass
+{
+    void TestMethod()
+    {
+        IAnsiConsole console = AnsiConsole.Console;
+        string world = ""World"";
+        console.MarkupLine($""[bold]Hello, {world}[/]"");
+    }
+}";
+
+        await SpectreAnalyzerVerifier<UseMarkupLineInterpolatedAnalyzer>
+            .VerifyAnalyzerAsync(Source, _expectedDiagnostics.WithLocation(10, 9));
+    }
+
+    [Fact]
+    public async Task MarkupLine_Without_Interpolation_Has_No_Warning()
+    {
+        const string Source = @"
+using Spectre.Console;
+
+class TestClass
+{
+    void TestMethod()
+    {
+
+        IAnsiConsole console = AnsiConsole.Console;
+        console.MarkupLine(""[bold]Hello, world[/]"");
+        AnsiConsole.MarkupLine(""[bold]Hello, world[/]"");
+    }
+}";
+
+        await SpectreAnalyzerVerifier<UseMarkupLineInterpolatedAnalyzer>
+            .VerifyAnalyzerAsync(Source);
+    }
+
+    [Fact]
+    public async Task MarkupLine_With_Interpolation_But_No_Replacement_Has_Warning()
+    {
+        // The only difference from the above test is that there is no replacement {..}
+        const string Source = @"
+using Spectre.Console;
+
+class TestClass
+{
+    void TestMethod()
+    {
+        IAnsiConsole console = AnsiConsole.Console;
+        console.MarkupLine($""[bold]Hello, world[/]"");
+        AnsiConsole.MarkupLine($""[bold]Hello, world[/]"");
+    }
+}";
+
+        await SpectreAnalyzerVerifier<UseMarkupLineInterpolatedAnalyzer>
+            .VerifyAnalyzerAsync(Source);
+    }
+}

--- a/src/Spectre.Console.Analyzer.Tests/Unit/Fixes/UseMarkupLineInterpolatedFixTests.cs
+++ b/src/Spectre.Console.Analyzer.Tests/Unit/Fixes/UseMarkupLineInterpolatedFixTests.cs
@@ -1,0 +1,72 @@
+namespace Spectre.Console.Analyzer.Tests.Unit.Fixes;
+
+public class UseMarkupLineInterpolatedFixTests
+{
+    private static readonly DiagnosticResult _expectedDiagnostic = new(
+        Descriptors.S1030_AvoidInterpolationInMarkupLine.Id,
+        DiagnosticSeverity.Warning);
+
+    [Fact]
+    public async Task AnsiConsoleExtensions_MarkupLine_replaced_with_MarkupLineInterpolated()
+    {
+        const string Source = @"
+using Spectre.Console;
+
+class TestClass
+{
+    void TestMethod()
+    {
+        IAnsiConsole console = AnsiConsole.Console;
+        var world = ""world"";
+        console.MarkupLine($""Hello, {world}"");
+    }
+}";
+
+        const string FixedSource = @"
+using Spectre.Console;
+
+class TestClass
+{
+    void TestMethod()
+    {
+        IAnsiConsole console = AnsiConsole.Console;
+        var world = ""world"";
+        console.MarkupLineInterpolated($""Hello, {world}"");
+    }
+}";
+
+        await SpectreAnalyzerVerifier<UseMarkupLineInterpolatedAnalyzer>
+            .VerifyCodeFixAsync(Source, _expectedDiagnostic.WithLocation(10, 9), FixedSource);
+    }
+
+    [Fact]
+    public async Task AnsiConsole_MarkupLine_replaced_with_MarkupLineInterpolated()
+    {
+        const string Source = @"
+using Spectre.Console;
+
+class TestClass
+{
+    void TestMethod()
+    {
+        var world = ""world"";
+        AnsiConsole.MarkupLine($""Hello, {world}"");
+    }
+}";
+
+        const string FixedSource = @"
+using Spectre.Console;
+
+class TestClass
+{
+    void TestMethod()
+    {
+        var world = ""world"";
+        AnsiConsole.MarkupLineInterpolated($""Hello, {world}"");
+    }
+}";
+
+        await SpectreAnalyzerVerifier<UseMarkupLineInterpolatedAnalyzer>
+            .VerifyCodeFixAsync(Source, _expectedDiagnostic.WithLocation(9, 9), FixedSource);
+    }
+}

--- a/src/Spectre.Console.Analyzer/Analyzers/UseMarkupLineInterpolatedAnalyzer.cs
+++ b/src/Spectre.Console.Analyzer/Analyzers/UseMarkupLineInterpolatedAnalyzer.cs
@@ -1,0 +1,91 @@
+namespace Spectre.Console.Analyzer;
+
+/// <summary>
+/// Analyzer to enforce the use of MarkupLineInterpolated over MarkupLine when using string interpolation.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class UseMarkupLineInterpolatedAnalyzer : SpectreAnalyzer
+{
+    private const string MarkupLine = "MarkupLine";
+
+    private static readonly DiagnosticDescriptor _diagnosticDescriptor =
+        Descriptors.S1030_AvoidInterpolationInMarkupLine;
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+        ImmutableArray.Create(_diagnosticDescriptor);
+
+    /// <inheritdoc />
+    protected override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext)
+    {
+        var spectreConsoleType =
+            compilationStartContext.Compilation.GetTypeByMetadataName("Spectre.Console.AnsiConsole");
+        var spectreConsoleInterface =
+            compilationStartContext.Compilation.GetTypeByMetadataName("Spectre.Console.AnsiConsoleExtensions");
+
+        compilationStartContext.RegisterOperationAction(
+            context =>
+            {
+                var invocationOperation = (IInvocationOperation)context.Operation;
+
+                // if this operation isn't an invocation against MarkupLine stop analyzing and return;
+                if (!invocationOperation.TargetMethod.Name.Equals(MarkupLine))
+                {
+                    return;
+                }
+
+                int argumentIndex = -1;
+
+                if (invocationOperation.TargetMethod.ContainingType.Equals(
+                        spectreConsoleType,
+                        SymbolEqualityComparer.Default))
+                {
+                    // This is a call to AnsiConsole.MarkupLine
+                    argumentIndex = 0;
+                }
+                else if (invocationOperation.TargetMethod.ContainingType.Equals(
+                             spectreConsoleInterface,
+                             SymbolEqualityComparer.Default))
+                {
+                    // This is a call to AnsiConsoleExtensions.MarkupLine
+                    argumentIndex = 1;
+                }
+
+                if (argumentIndex == -1)
+                {
+                    return;
+                }
+
+                // if there are no arguments stop analyzing and return
+                if (invocationOperation.Arguments.Length <= argumentIndex)
+                {
+                    return;
+                }
+
+                var argument = invocationOperation.Arguments[argumentIndex].Value;
+                if (argument is not IInterpolatedStringOperation interpolatedString)
+                {
+                    return;
+                }
+
+                var hasInterpolation = interpolatedString.Parts.OfType<IInterpolationOperation>().Any();
+                if (!hasInterpolation)
+                {
+                    return; // no actual interpolation in the string, future analyzer to suggest MarkupLine
+                }
+
+                // Here it is MarkupLine with string interpolation.
+                var displayString = SymbolDisplay.ToDisplayString(
+                    invocationOperation.TargetMethod,
+                    SymbolDisplayFormat.CSharpShortErrorMessageFormat
+                        .WithParameterOptions(SymbolDisplayParameterOptions.None)
+                        .WithGenericsOptions(SymbolDisplayGenericsOptions.None));
+
+                context.ReportDiagnostic(
+                    Diagnostic.Create(
+                        _diagnosticDescriptor,
+                        invocationOperation.Syntax.GetLocation(),
+                        displayString));
+            }, OperationKind.Invocation);
+    }
+}

--- a/src/Spectre.Console.Analyzer/Descriptors.cs
+++ b/src/Spectre.Console.Analyzer/Descriptors.cs
@@ -73,4 +73,15 @@ public static class Descriptors
             Usage,
             Warning,
             "Avoid prompting for input while a current renderable is running.");
+
+    /// <summary>
+    /// Gets the definitions of diagnostics Spectre1030.
+    /// </summary>
+    public static DiagnosticDescriptor S1030_AvoidInterpolationInMarkupLine { get; } =
+        Rule(
+            "Spectre1030",
+            "Avoid using string interpolation in MarkupLine.",
+            Usage,
+            Warning,
+            "Avoid using string interpolation in MarkupLine. Use MarkupLineInterpolated instead.");
 }

--- a/src/Spectre.Console.Analyzer/Fixes/CodeActions/SwitchToMarkupLineInterpolatedAction.cs
+++ b/src/Spectre.Console.Analyzer/Fixes/CodeActions/SwitchToMarkupLineInterpolatedAction.cs
@@ -1,0 +1,54 @@
+using Microsoft.CodeAnalysis.Editing;
+
+namespace Spectre.Console.Analyzer.CodeActions;
+
+/// <summary>
+/// Code action to switch to MarkupLineInterpolated.
+/// </summary>
+public class SwitchToMarkupLineInterpolatedAction : CodeAction
+{
+    private readonly Document _document;
+    private readonly InvocationExpressionSyntax _originalInvocation;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SwitchToMarkupLineInterpolatedAction"/> class.
+    /// </summary>
+    /// <param name="document">Document to change.</param>
+    /// <param name="originalInvocation">The method to change.</param>
+    /// <param name="title">Title of the fix.</param>
+    public SwitchToMarkupLineInterpolatedAction(Document document, InvocationExpressionSyntax originalInvocation, string title)
+    {
+        _document = document;
+        _originalInvocation = originalInvocation;
+        Title = title;
+    }
+
+    /// <inheritdoc />
+    public override string Title { get; }
+
+    /// <inheritdoc />
+    public override string EquivalenceKey => Title;
+
+    /// <inheritdoc />
+    protected override async Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
+    {
+        var editor = await DocumentEditor.CreateAsync(_document, cancellationToken).ConfigureAwait(false);
+
+        // Ensure the invocation is actually a method call on AnsiConsole
+        if (_originalInvocation.Expression is not MemberAccessExpressionSyntax memberAccess)
+        {
+            return _document;
+        }
+
+        // Replace MarkupLine with MarkupLineInterpolated
+        var newMemberAccess = memberAccess.WithName(SyntaxFactory.IdentifierName("MarkupLineInterpolated"));
+
+        // Create a new invocation with the updated method name
+        var newInvocation = _originalInvocation.WithExpression(newMemberAccess);
+
+        // Apply the fix by replacing the old invocation with the new one
+        editor.ReplaceNode(_originalInvocation, newInvocation);
+
+        return editor.GetChangedDocument();
+    }
+}

--- a/src/Spectre.Console.Analyzer/Fixes/FixProviders/UseMarkupLineInterpolatedFix.cs
+++ b/src/Spectre.Console.Analyzer/Fixes/FixProviders/UseMarkupLineInterpolatedFix.cs
@@ -1,0 +1,37 @@
+namespace Spectre.Console.Analyzer.FixProviders;
+
+/// <summary>
+/// Fix provider to change MarkupLine calls to MarkupLineInterpolated calls.
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp)]
+[Shared]
+public class UseMarkupLineInterpolatedFix : CodeFixProvider
+{
+    /// <inheritdoc />
+    public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(
+        Descriptors.S1030_AvoidInterpolationInMarkupLine.Id);
+
+    /// <inheritdoc />
+    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc />
+    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+        var diagnostic = context.Diagnostics[0];
+        var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+        if (root?.FindNode(diagnosticSpan) is not InvocationExpressionSyntax invocationExpression)
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            new SwitchToMarkupLineInterpolatedAction(
+                context.Document,
+                invocationExpression,
+                "Convert MarkupLine to MarkupLineInterpolated"),
+            context.Diagnostics);
+    }
+}


### PR DESCRIPTION
This addresses one of the issues in #1 specifically the first example and doesn't cover other overloads of MarkupLine.

Added new diagnostic Spectre1030 (can change this to whatever is needed.)
- Will need a website page for it?
- I just picked a number.

Added UseMarkupLineInterpolatedAnalyzer
- Looks for AnsiConsole or AnsiConsoleExtensions `.MarkupLine`
- Checks if MarkupLine is doing string interpolation.
- Checks if it actually has a part that is interpolated
  - Room for more analyzers here like if MarkupLineInterpolated is used but nothing interpolated. (future PR if this one is accepted.)
- If so it warns to use MarkupLineInterpolated.

Added SwitchToMarkupLineInterpolatedAction
- Allowing code fix for MarkupLine -> MarkupLineInterpolated

Added tests for analyzer and code fix.